### PR TITLE
feat: add image gallery page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import PptxViewer from './pages/PptxViewer';
 import Analytics from './pages/Analytics';
 import PersonalBlog from './pages/PersonalBlog';
 import BlogPost from './pages/BlogPost';
+import Gallery from './pages/Gallery';
 
 const App: React.FC = () => {
   const { getAccessTokenSilently, user,isAuthenticated, loginWithRedirect, logout } = useAuth0();
@@ -49,6 +50,7 @@ const App: React.FC = () => {
             <Route path="/analytics" element={<Analytics />} />
             <Route path="/blog" element={<PersonalBlog />} />
             <Route path="/blog/:slug" element={<BlogPost />} />
+            <Route path="/gallery" element={<Gallery />} />
           </Routes>
     
           <Footer/>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,7 @@ const Header: React.FC = () => {
           <Link href="/pptx?src=/sample.pptx" color="black">PPTX</Link>
           <Link href="/analytics" color="black">Analytics</Link>
           <Link href="/blog" color="black">Blog</Link>
+          <Link href="/gallery" color="black">Gallery</Link>
         </HStack>
         {isAuthenticated ? (
             <Button onClick={() => logout({ logoutParams: {returnTo: window.location.origin }})}>

--- a/src/pages/Gallery.tsx
+++ b/src/pages/Gallery.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Box, SimpleGrid, Image } from '@chakra-ui/react';
+import az104 from '../assets/az-104.png';
+import az104a from '../assets/az-104a.png';
+import az900 from '../assets/az-900.png';
+import genericImage from '../assets/image.png';
+import reactLogo from '../assets/react.svg';
+
+const Gallery: React.FC = () => {
+  const images = [az104, az104a, az900, genericImage, reactLogo];
+
+  return (
+    <Box p={8}>
+      <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={4}>
+        {images.map((src, index) => (
+          <Image key={index} src={src} alt={`gallery-image-${index}`} />
+        ))}
+      </SimpleGrid>
+    </Box>
+  );
+};
+
+export default Gallery;


### PR DESCRIPTION
## Summary
- add gallery page to display images
- include gallery route and navigation link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: existing lint errors)*
- `npm run build` *(fails: existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b420a8b8c48333baf79c32d938d35d